### PR TITLE
Update build_tag_push_with_buildenv.yml

### DIFF
--- a/.github/workflows/build_tag_push_with_buildenv.yml
+++ b/.github/workflows/build_tag_push_with_buildenv.yml
@@ -43,7 +43,7 @@ on:
         required: false
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Changing the runners to self-hosted as issue was resolved with Github token change.