### PR TITLE
Remove references to ECS cluster

### DIFF
--- a/.github/workflows/ecs_generic_deploy.yml
+++ b/.github/workflows/ecs_generic_deploy.yml
@@ -162,14 +162,6 @@ jobs:
           task-definition: task_def.json
           container-name: ${{inputs.environment}}-${{inputs.app_name}}
           image: ${{ steps.image-name.outputs.image }}
-
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{inputs.environment}}-${{inputs.app_name}}
-          cluster: ${{ steps.set_region.outputs.cluster }}-ecs-cluster
-          wait-for-service-stability: true
           
       - name: Task Def Cleaner
         uses: ScrumWorks/github-actions-aws-task-cleaner@v1

--- a/.github/workflows/ecs_migration_task_run.yml
+++ b/.github/workflows/ecs_migration_task_run.yml
@@ -205,7 +205,6 @@ jobs:
             fi
           done
 
-
       - name: Execute AWS ECS Task Definition
         id: run_tsk_def
         run: |

--- a/.github/workflows/ecs_migration_task_run.yml
+++ b/.github/workflows/ecs_migration_task_run.yml
@@ -205,18 +205,6 @@ jobs:
             fi
           done
 
-      - name: Execute AWS ECS Task Definition
-        id: run_tsk_def
-        run: |
-          echo "::set-output name=task_arn::`aws ecs run-task --cluster ${{inputs.environment}}-ecs-cluster --task-definition ${{inputs.environment}}-${{inputs.app_name}}-migrations:${{ steps.reg_tsk_def.outputs.task_revision }} --region ${{ steps.set_region.outputs.region }} --launch-type EC2 --output json | jq .tasks | jq '.[0].taskArn'`"
-
-      - name: Migration Task Wait
-        id: tsk_run_wait
-        run: |
-          aws ecs wait tasks-stopped --cluster ${{inputs.environment}}-ecs-cluster --tasks ${{ steps.run_tsk_def.outputs.task_arn }}
-          EXITCODE=`aws ecs describe-tasks --cluster ${{inputs.environment}}-ecs-cluster --tasks ${{ steps.run_tsk_def.outputs.task_arn }} | jq '.tasks[].containers[] | select(.name=="${{inputs.environment}}-${{inputs.app_name}}-migrations") | .exitCode'`
-          exit $EXITCODE
-
       - name: Task Def Cleaner
         uses: ScrumWorks/github-actions-aws-task-cleaner@v1
         with:

--- a/.github/workflows/ecs_multi_env_deploy.yml
+++ b/.github/workflows/ecs_multi_env_deploy.yml
@@ -131,14 +131,6 @@ jobs:
           task-definition: task_def.json
           container-name: ${{inputs.environment}}-${{inputs.app_name}}
           image: ${{ steps.image-name.outputs.image }}
-
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{inputs.environment}}-${{inputs.app_name}}
-          cluster: ${{ steps.set_region.outputs.cluster }}-ecs-cluster
-          wait-for-service-stability: true
           
       - name: Task Def Cleaner
         uses: ScrumWorks/github-actions-aws-task-cleaner@v1


### PR DESCRIPTION
If changes are required to services remaining in the prod ECS cluster effort should be done to migrate that service into the various EKS clusters.