### PR TITLE
Most places cut the GITHUB_SHA at 8

### DIFF
--- a/.github/workflows/build_mfe.yml
+++ b/.github/workflows/build_mfe.yml
@@ -74,7 +74,7 @@ jobs:
       name: Set Git‑related outputs
       shell: bash
       run: |
-        echo "::set-output name=github_sha_tag::$(echo "${GITHUB_SHA}" | cut -c1-7)"
+        echo "::set-output name=github_sha_tag::$(echo "${GITHUB_SHA}" | cut -c1-8)"
         echo "::set-output name=github_head_ref::${GITHUB_HEAD_REF%%/*}"
         echo "::set-output name=github_ref::${GITHUB_REF}"
         echo "::set-output name=github_ref_name::${GITHUB_REF_NAME}"
@@ -168,7 +168,7 @@ jobs:
     - id: short_sha
       name: Export short commit SHA
       shell: bash
-      run: echo "::set-output name=tag::$(echo "${GITHUB_SHA}" | cut -c1-7)"
+      run: echo "::set-output name=tag::$(echo "${GITHUB_SHA}" | cut -c1-8)"
 
     # ──────────────────────────── AWS CLI (needed for s3 cp) ──────────────────
     - name: Install AWS CLI v2

--- a/.github/workflows/build_mfe_em.yml
+++ b/.github/workflows/build_mfe_em.yml
@@ -74,7 +74,7 @@ jobs:
       name: Set Git‑related outputs
       shell: bash
       run: |
-        echo "::set-output name=github_sha_tag::$(echo "${GITHUB_SHA}" | cut -c1-7)"
+        echo "::set-output name=github_sha_tag::$(echo "${GITHUB_SHA}" | cut -c1-8)"
         echo "::set-output name=github_head_ref::${GITHUB_HEAD_REF%%/*}"
         echo "::set-output name=github_ref::${GITHUB_REF}"
         echo "::set-output name=github_ref_name::${GITHUB_REF_NAME}"
@@ -160,7 +160,7 @@ jobs:
     - id: short_sha
       name: Export short commit SHA
       shell: bash
-      run: echo "::set-output name=tag::$(echo "${GITHUB_SHA}" | cut -c1-7)"
+      run: echo "::set-output name=tag::$(echo "${GITHUB_SHA}" | cut -c1-8)"
 
     # ──────────────────────────── AWS CLI (needed for s3 cp) ──────────────────
     - name: Install AWS CLI v2


### PR DESCRIPTION
There is an issue at least with form-frontend where the folder in micro-frontend-artifacts is 7 characters of the GITHUB_SHA but the deploy is looking for a folder with 8 characters.

Note a change likely needs to be made for workflow service as well.