### PR TITLE
Triggers carecru-deployment-configs (or other target) via repository_…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+# Triggers carecru-deployment-configs (or other target) via repository_dispatch.
+# Uses a GitHub App installation token instead of PAT_DEVOPS.
+name: Deploy
+
+on:
+  workflow_call:
+    inputs:
+      env:
+        description: Target environment (dev, test, prod, prod-us)
+        required: true
+        type: string
+      app:
+        description: Application name (ArgoCD manifest basename, e.g. form)
+        required: true
+        type: string
+      tag:
+        description: Version tag to deploy (short SHA or release tag)
+        required: true
+        type: string
+      target_repo:
+        description: CareCru repository the GitHub App token is scoped to
+        required: false
+        type: string
+        default: carecru-deployment-configs
+      repository:
+        description: repository_dispatch target (owner/repo)
+        required: false
+        type: string
+        default: CareCru/carecru-deployment-configs
+      event_type:
+        description: repository_dispatch event-type
+        required: false
+        type: string
+        default: update_application_version
+    secrets:
+      app_id:
+        description: GitHub App ID for repository dispatch
+        required: true
+      app_private_key:
+        description: GitHub App private key
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+          owner: CareCru
+          repositories: ${{ inputs.target_repo }}
+
+      - name: Trigger deployment config update
+        uses: peter-evans/repository-dispatch@v4.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ inputs.repository }}
+          event-type: ${{ inputs.event_type }}
+          client-payload: >-
+            {"env": "${{ inputs.env }}", "app": "${{ inputs.app }}", "tag": "${{ inputs.tag }}"}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,8 @@ on:
         type: string
         default: update_application_version
     secrets:
-      app_id:
-        description: GitHub App ID for repository dispatch
+      client_id:
+        description: GitHub Client ID for repository dispatch
         required: true
       app_private_key:
         description: GitHub App private key
@@ -48,7 +48,7 @@ jobs:
         uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.client_id }}
           private-key: ${{ secrets.app_private_key }}
           owner: CareCru
           repositories: ${{ inputs.target_repo }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub App token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.app_id }}

--- a/.github/workflows/deploy_mfe.yml
+++ b/.github/workflows/deploy_mfe.yml
@@ -1,5 +1,5 @@
 # Triggers carecru-deployment-configs to bump release and sync via Helm MFE hook (ArgoCD).
-# v4 breaking change: replaces direct S3 copy; requires pat_devops and app/mfe_service_name inputs.
+# v4 breaking change: replaces direct S3 copy; requires GitHub App secrets and app/mfe_service_name inputs.
 name: Deploy MFE
 
 on:
@@ -22,19 +22,36 @@ on:
         required: false
         type: string
         default: ""
+      target_repo:
+        description: CareCru repository the GitHub App token is scoped to
+        required: false
+        type: string
+        default: carecru-deployment-configs
     secrets:
-      pat_devops:
-        description: PAT with repo dispatch access to carecru-deployment-configs
+      app_id:
+        description: GitHub App ID for repository dispatch
+        required: true
+      app_private_key:
+        description: GitHub App private key
         required: true
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+          owner: CareCru
+          repositories: ${{ inputs.target_repo }}
+
       - name: Trigger carecru-deployment-configs update
         uses: peter-evans/repository-dispatch@v4.0.1
         with:
-          token: ${{ secrets.pat_devops }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: CareCru/carecru-deployment-configs
           event-type: update_application_version
           client-payload: >-

--- a/.github/workflows/deploy_mfe.yml
+++ b/.github/workflows/deploy_mfe.yml
@@ -28,8 +28,8 @@ on:
         type: string
         default: carecru-deployment-configs
     secrets:
-      app_id:
-        description: GitHub App ID for repository dispatch
+      client_id:
+        description: GitHub Client ID for repository dispatch
         required: true
       app_private_key:
         description: GitHub App private key
@@ -43,7 +43,7 @@ jobs:
         uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.client_id }}
           private-key: ${{ secrets.app_private_key }}
           owner: CareCru
           repositories: ${{ inputs.target_repo }}


### PR DESCRIPTION
…dispatch.

Uses a GitHub App installation token instead of PAT_DEVOPS